### PR TITLE
Add shared SonarQube Maven analysis workflow

### DIFF
--- a/.github/workflows/sonar-maven.yml
+++ b/.github/workflows/sonar-maven.yml
@@ -1,0 +1,109 @@
+name: Sonar Maven analysis
+
+on:
+  workflow_call:
+    inputs:
+      java_version:
+        description: Build Java version
+        type: string
+        default: "21"
+      project_key:
+        description: Target project key in SonarQube server
+        type: string
+        default: ${{ vars.SONAR_PROJECT_KEY }}
+      pull_request:
+        description: Associated pull request event
+        type: string
+      save_cache:
+        description: Whether to persist analysis caches
+        type: boolean
+        default: false
+    secrets:
+      SONAR_TOKEN:
+        description: SonarQube analysis API token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: Prepare parameters
+    outputs:
+      sonar_args: ${{ steps.params.outputs.sonar_args }}
+      check_ref: ${{ steps.params.outputs.check_ref }}
+      runner_platform: ${{ steps.params.outputs.runner_platform }}
+    steps:
+      - name: Prepare parameters
+        id: params
+        shell: bash
+        env:
+          PULL_REQUEST_EVENT: ${{ inputs.pull_request }}
+          RUNNER_PLATFORM: ${{ runner.os }}-${{ runner.arch }}
+        run: |
+          SONAR_ARGS="-Dsonar.projectKey=${{ inputs.project_key }}"
+          if [[ $PULL_REQUEST_EVENT ]]; then
+            SONAR_ARGS="$SONAR_ARGS $(echo $PULL_REQUEST_EVENT | jq -r '[
+              "-Dsonar.pullrequest.key=\(.number)",
+              "-Dsonar.pullrequest.branch=\(.head.ref)",
+              "-Dsonar.pullrequest.base=\(.base.ref)",
+              "-Dsonar.pullrequest.github.repository=\(.repo.name)",
+              "-Dsonar.pullrequest.provider=GitHub"
+            ] | join(" ")')"
+          fi
+          echo "sonar_args=$SONAR_ARGS" >> $GITHUB_OUTPUT
+
+          CHECK_REF=main
+          if [[ $PULL_REQUEST_EVENT ]]; then
+            echo CHECK_REF=$(echo "$PULL_REQUEST_EVENT" | jq -r .head.sha)
+          fi
+          echo "check_ref=$CHECK_REF" >> "$GITHUB_OUTPUT"
+
+          echo "runner_platform=$RUNNER_PLATFORM" >> "$GITHUB_OUTPUT"
+  analyze:
+    runs-on: ubuntu-latest
+    name: Perform analysis
+    needs: prepare
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.check_ref }}
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "${{ inputs.java_version }}"
+      - name: Restore Maven cache
+        id: restore-maven-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2
+          key: sonar-maven-${{ needs.prepare.outputs.runner_platform }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: sonar-maven-${{ needs.prepare.outputs.runner_platform }}-
+      - name: Restore Sonar cache
+        id: restore-sonar-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.sonar/cache
+          key: sonar-cache-${{ needs.prepare.outputs.runner_platform }}
+      - name: Run Sonar analysis
+        env:
+          SONAR_ARGS: ${{ needs.prepare.outputs.sonar_args }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn $SONAR_ARGS -P metrics verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+      - name: Save Maven cache
+        if: inputs.save_cache && !steps.restore-maven-cache.outputs.cache-hit
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2
+          key: ${{ steps.restore-maven-cache.outputs.cache-primary-key }}
+      - name: Save Sonar cache
+        if: inputs.save_cache && !steps.restore-sonar-cache.outputs.cache-hit
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ steps.restore-sonar-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
This PR adds a reusable SonarQube Maven analysis workflow that can be called from other Wren Security projects.

Me and @adela-domokosova have invested quite a lot of time (unreasonable amount TBH) to get a setup which can run SonarQube analysis in a safe manner. Let me summarize our findings and conclusions in the following text.

First, the reason behind introducing SonarQube Cloud are obvious:

* We want to have a tool to track our code-quality / security metrics in time.
* We want to evaluate code changes in relation to those metrics... and we are not aware of any tool (or Maven plugin) that can do this locally.

Next the big limitation of SonarQube analysis done by SonarScanner:

* Even though the analysis is being done in a static way, it requires active SonarQube server connection. This means running analysis requires `SONAR_TOKEN` secret that is not available in GitHub's workflow runs triggered by a `pull_request` event.
* It might seem that it should be safe to run static analysis on an untrusted codebase, however in case of SonnarScanner for Maven, it is not true. Running any Maven plugin on top of untrusted pom.xml opens up doors for RCE exploits. Hence running SonnarScanner for Maven on PR code must be treated with extra caution.
* The only safe way would be to run SonarScanner CLI, however the analysis requires a lot of inputs that is very hard to construct without the help of a Maven project model. It is possible (we have tried), but there is a tradeoff between *"managing / accepting the risk of running SonnarScanner for Maven"* and *"having complex setup to collect analysis parameters and artifacts, while having them to transfer to a different environment for isolated SonarScanner CLI run"*.

So what we ended up with:

* We have created shared SonarQube Maven analysis workflow (content of this PR). This workflow can be called from any Wren Security Maven project.
* The shared workflow performs full project build.
   * We don't transfer artifacts built by earlier stages / workflows (as seen in other projects) - such approaches do not bring any additional security (as described above), only more complexity to the standard (usually matrix based) build workflow setup.
   * This also means that for the SonarQube analysis we do additional full project build which wastes some CI resources. The analysis will be preceded by a standard project build, which would be usually matrix build that builds the project e.g. 6-times over, so one more build is not that big of a deal. And we don't have to introduce additional complexity to the standard build workflows.
   
What about `SONAR_TOKEN` and the risk of untrusted code execution:

* We expect this workflow to be run as a result of a successful run of a standard build workflow (`workflow_run` event). First time contributors will need manual approval for the `push_request` triggered workflows which means this workflow will also wait for the approval. So new contributors won't be able to execute this workflow without approval.
* Also having `SONAR_TOKEN` leaked is not a critical issue. `SONAR_TOKENS` are project scoped and can be rotated if needed. Malicious users can be blocked in GitHub organization.
* The only issue might be actually discovering that the token has been leaked. Code-reviewers have to be cautious (and they / we are) to watch what is being actually pushed and reported by SonarQube.
