### PR TITLE
Improve shared SonarQube workflows

### DIFF
--- a/.github/workflows/sonar-maven.yml
+++ b/.github/workflows/sonar-maven.yml
@@ -12,14 +12,10 @@ on:
         type: string
         default: ${{ vars.SONAR_PROJECT_KEY }}
       pull_request:
-        description: Associated pull request event
+        description: Associated pull_request event
         type: string
-      save_cache:
-        description: Whether to persist analysis caches
-        type: boolean
-        default: false
     secrets:
-      SONAR_TOKEN:
+      sonar_token:
         description: SonarQube analysis API token
         required: true
 
@@ -33,14 +29,13 @@ jobs:
     outputs:
       sonar_args: ${{ steps.params.outputs.sonar_args }}
       check_ref: ${{ steps.params.outputs.check_ref }}
-      runner_platform: ${{ steps.params.outputs.runner_platform }}
+      cache_key: ${{ steps.params.outputs.cache_key }}
     steps:
       - name: Prepare parameters
         id: params
         shell: bash
         env:
           PULL_REQUEST_EVENT: ${{ inputs.pull_request }}
-          RUNNER_PLATFORM: ${{ runner.os }}-${{ runner.arch }}
         run: |
           SONAR_ARGS="-Dsonar.projectKey=${{ inputs.project_key }}"
           if [[ $PULL_REQUEST_EVENT ]]; then
@@ -48,7 +43,7 @@ jobs:
               "-Dsonar.pullrequest.key=\(.number)",
               "-Dsonar.pullrequest.branch=\(.head.ref)",
               "-Dsonar.pullrequest.base=\(.base.ref)",
-              "-Dsonar.pullrequest.github.repository=\(.repo.name)",
+              "-Dsonar.pullrequest.github.repository=\(.base.repo.name)",
               "-Dsonar.pullrequest.provider=GitHub"
             ] | join(" ")')"
           fi
@@ -56,11 +51,15 @@ jobs:
 
           CHECK_REF=main
           if [[ $PULL_REQUEST_EVENT ]]; then
-            echo CHECK_REF=$(echo "$PULL_REQUEST_EVENT" | jq -r .head.sha)
+            CHECK_REF=$(echo "$PULL_REQUEST_EVENT" | jq -r .head.sha)
           fi
           echo "check_ref=$CHECK_REF" >> "$GITHUB_OUTPUT"
 
-          echo "runner_platform=$RUNNER_PLATFORM" >> "$GITHUB_OUTPUT"
+          CACHE_KEY=base
+          if [[ $PULL_REQUEST_EVENT ]]; then
+            CACHE_KEY=pull-$(echo "$PULL_REQUEST_EVENT" | jq -r .number)
+          fi
+          echo "cache_key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
   analyze:
     runs-on: ubuntu-latest
     name: Perform analysis
@@ -76,34 +75,23 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "${{ inputs.java_version }}"
-      - name: Restore Maven cache
-        id: restore-maven-cache
-        uses: actions/cache/restore@v4
+      - name: Set up Maven cache
+        uses: actions/cache@v4
         with:
           path: ~/.m2
-          key: sonar-maven-${{ needs.prepare.outputs.runner_platform }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: sonar-maven-${{ needs.prepare.outputs.runner_platform }}-
-      - name: Restore Sonar cache
-        id: restore-sonar-cache
-        uses: actions/cache/restore@v4
+          key: sonar-maven-${{ runner.os }}-${{ runner.arch }}-${{ needs.prepare.outputs.cache_key }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            sonar-maven-${{ runner.os }}-${{ runner.arch }}-base-${{ hashFiles('**/pom.xml') }}
+            sonar-maven-${{ runner.os }}-${{ runner.arch }}-base-
+      - name: Set up Sonar cache
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
-          key: sonar-cache-${{ needs.prepare.outputs.runner_platform }}
+          key: sonar-cache-${{ runner.os }}-${{ runner.arch }}-${{ needs.prepare.outputs.cache_key }}
+          restore-keys: sonar-cache-${{ runner.os }}-${{ runner.arch }}-base
       - name: Run Sonar analysis
         env:
           SONAR_ARGS: ${{ needs.prepare.outputs.sonar_args }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.sonar_token }}
         run: |
           mvn $SONAR_ARGS -P metrics verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-      - name: Save Maven cache
-        if: inputs.save_cache && !steps.restore-maven-cache.outputs.cache-hit
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.m2
-          key: ${{ steps.restore-maven-cache.outputs.cache-primary-key }}
-      - name: Save Sonar cache
-        if: inputs.save_cache && !steps.restore-sonar-cache.outputs.cache-hit
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ steps.restore-sonar-cache.outputs.cache-primary-key }}

--- a/.github/workflows/sonar-pull-maven.yml
+++ b/.github/workflows/sonar-pull-maven.yml
@@ -1,0 +1,45 @@
+name: Handle Maven analysis
+
+on:
+  workflow_call:
+    inputs:
+      workflow_run:
+        description: Associated workflow_run event
+        type: string
+        required: true
+    secrets:
+      sonar_token:
+        description: SonarQube analysis API token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: Prepare context
+    outputs:
+      pull_request: ${{ steps.export.outputs.pull_request }}
+    steps:
+      - name: Fetch pull_request
+        uses: actions/download-artifact@v4
+        with:
+          name: pull_request
+          run-id: ${{ fromJSON(inputs.workflow_run).id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Export context values
+        id: export
+        shell: bash
+        run: |
+          if [ -f pull_request.json ]; then
+            echo "pull_request=$(cat pull_request.json | jq -c .)" >> "$GITHUB_OUTPUT"
+          fi
+  analyze:
+    name: Sonar analysis
+    needs: prepare
+    if: fromJSON(needs.prepare.outputs.pull_request).base.ref == 'main'
+    uses: ./.github/workflows/sonar-maven.yml
+    with:
+      pull_request: ${{ needs.prepare.outputs.pull_request }}
+    secrets: inherit

--- a/.github/workflows/sonar-pull-prepare.yml
+++ b/.github/workflows/sonar-pull-prepare.yml
@@ -1,0 +1,45 @@
+name: Prepare analysis context
+
+on:
+  workflow_call:
+    inputs:
+      pull_request:
+        description: Associated pull request event
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: Prepare analysis context
+    steps:
+      - name: Copy event payload
+        env:
+          GITHUB_PULL_REQUEST: ${{ inputs.pull_request }}
+        run: |
+          cat "$GITHUB_EVENT_PATH" | jq '
+            .pull_request | 
+            {
+              number,
+              head: {
+                ref: .head.ref,
+                sha: .head.sha,
+                repo: {
+                  name: .head.repo.name
+                }
+              },
+              base: {
+                ref: .base.ref,
+                repo: {
+                  name: .base.repo.name
+                }
+              }
+            }' > pull_request.json
+      - name: Upload event payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: pull_request
+          path: pull_request.json


### PR DESCRIPTION
This PR improves on the previous one (#3):

* add additional shared workflows to make our life easier in project repositories
   * sonar-pull-prepare - attaches pull_request event payload
   * sonar-pull-maven - handles downloading pull_request payload and calls sonar-maven workflow
* pull_request payload is now filtered to contain only the required properties
* Maven ans Sonar caches are now persisted even for PR based workflow runs
