### PR TITLE
Allow setting custom Sonar and build properties

### DIFF
--- a/.github/workflows/sonar-maven.yml
+++ b/.github/workflows/sonar-maven.yml
@@ -14,6 +14,12 @@ on:
       pull_request:
         description: Associated pull_request event
         type: string
+      build_args:
+        description: Additional build arguments
+        type: string
+      scanner_opts:
+        description: SonarScanner Java options
+        type: string
     secrets:
       sonar_token:
         description: SonarQube analysis API token
@@ -91,7 +97,9 @@ jobs:
           restore-keys: sonar-cache-${{ runner.os }}-${{ runner.arch }}-base
       - name: Run Sonar analysis
         env:
+          BUILD_ARGS: ${{ inputs.build_args }}
           SONAR_ARGS: ${{ needs.prepare.outputs.sonar_args }}
           SONAR_TOKEN: ${{ secrets.sonar_token }}
+          SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner_opts }}
         run: |
-          mvn $SONAR_ARGS -P metrics verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          mvn $BUILD_ARGS $SONAR_ARGS -P metrics verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar


### PR DESCRIPTION
As we are having issues running analysis on Wren:AM project (probably because it uses so much static/global state and service binding), we need to be able to reduce the scope of analysis (e.g. by building only a selected set of projects). These new arguments will allow doing that (e.g. via `build_args: "-pl openam-server-only,openam-console -am"`).