### PR TITLE
Fix generated PR title and body

### DIFF
--- a/.github/workflows/backport-prepare.yml
+++ b/.github/workflows/backport-prepare.yml
@@ -125,7 +125,7 @@ jobs:
             const pr = JSON.parse(process.env.PULL_REQUEST);
 
             await github.rest.pulls.create({
-              title: `Backport PR #${pr.number} to ${process.env.BACKPORT_TARGET}`,
+              title: `${pr.title} (backport)`,
               owner,
               repo,
               head: process.env.BACKPORT_BRANCH,
@@ -134,5 +134,8 @@ jobs:
 
               Original title: ${pr.title}
               Original author: ${pr.user.login}
-              Original body: ${pr.body}`
+
+              ---
+
+              ${pr.body}`
             });


### PR DESCRIPTION
This pull request improves the automatically generated backport pull request. The generated PR now uses a clearer PR title, and the formatting includes a separator (`---`) between the metadata (original title and author) and the original PR body.